### PR TITLE
feat(api): configure Swagger/OpenAPI with SpringDoc

### DIFF
--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -11,3 +11,13 @@ spring:
     open-in-view: false
   flyway:
     enabled: true
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs
+  info:
+    title: PowerTools API
+    description: REST API for the PowerTools e-commerce platform
+    version: 0.0.1-SNAPSHOT


### PR DESCRIPTION
Add OpenAPI info (title, description, version) and explicit paths for Swagger UI (/swagger-ui.html) and API docs (/v3/api-docs).