### PR TITLE
Merge infrastructure + CI setup into main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /api
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: "Asia/Colombo"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - backend
+
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: "Asia/Colombo"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - frontend
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: "Asia/Colombo"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - ci

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+<!--
+  PowerTools Pull Request Template
+  Please fill out the sections below. Delete/keep the optional parts as appropriate.
+-->
+## Summary
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code cleanup
+- [ ] Documentation update
+- [ ] CI / build / tooling
+- [ ] Dependency update
+- [ ] Database migration (Flyway)
+
+## Related issue(s)
+
+<!-- Link any GitHub issues, e.g. "Closes #42" or "Part of #1". -->
+Closes #
+
+## What changed
+
+<!-- Describe the changes in detail and why they were made. -->
+
+## How it was tested
+
+<!-- Manual and automated steps run to verify. -->
+
+- [ ] Backend: `mvn clean verify` passed
+- [ ] Frontend: `pnpm lint` passed
+- [ ] Frontend: `pnpm typecheck` passed
+- [ ] Frontend: `pnpm build` passed
+
+## Breaking changes / migration notes
+
+<!-- Any breaking changes, DB migrations, or config that reviewers must know about. -->
+
+## Screenshots (for UI changes)
+
+<!-- Drag and drop screenshots here, if applicable. -->
+
+## Checklist
+
+- [ ] Branch is up to date with `main` and has no merge conflicts
+- [ ] Code follows the project's code style
+- [ ] Relevant tests pass
+- [ ] No secrets or credentials committed (`.env` files must never be pushed)
+- [ ] New dependencies are justified

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,65 @@
+name: Backend CI
+
+on:
+  push:
+    paths:
+      - "api/**"
+      - ".github/workflows/backend-ci.yml"
+  pull_request:
+    paths:
+      - "api/**"
+      - ".github/workflows/backend-ci.yml"
+
+concurrency:
+  group: ci-backend-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and test (Spring Boot API)
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: powertools_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_NAME: powertools_test
+      DB_USERNAME: root
+      DB_PASSWORD: root
+      DB_SSL: "false"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Build and test with Maven
+        working-directory: api
+        run: mvn -B clean verify
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-test-reports
+          path: api/target/surefire-reports/
+          if-no-files-found: ignore

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,75 @@
+name: Frontend CI
+
+on:
+  push:
+    paths:
+      - "web/**"
+      - ".github/workflows/frontend-ci.yml"
+  pull_request:
+    paths:
+      - "web/**"
+      - ".github/workflows/frontend-ci.yml"
+
+concurrency:
+  group: ci-frontend-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-typecheck:
+    name: Lint and typecheck (Next.js web)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+  build:
+    name: Build (Next.js web)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 11.25.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -60,6 +62,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 11.25.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,34 @@
+name: PR Template Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+concurrency:
+  group: pr-template-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate-template:
+    name: Validate PR follows template
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Ensure PR template file exists
+        run: test -f .github/pull_request_template.md && echo "PR template present"
+
+      - name: Validate PR body contains required sections
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          for section in "## Summary" "## Type of change" "## What changed" "## How it was tested"; do
+            if ! printf '%s' "$PR_BODY" | grep -Fq "$section"; then
+              echo "::error::PR body is missing required section: $section"
+              echo "Please fill out the template in .github/pull_request_template.md"
+              exit 1
+            fi
+          done
+          echo "PR body contains all required template sections."

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,6 +1,6 @@
 DB_HOST=localhost
 DB_PORT=3306
-DB_NAME=powertools
+DB_NAME=sliit
 DB_USERNAME=root
 DB_PASSWORD=
 DB_SSL=false

--- a/api/src/main/java/com/jayarathna/powertools/controller/HealthController.java
+++ b/api/src/main/java/com/jayarathna/powertools/controller/HealthController.java
@@ -1,0 +1,22 @@
+package com.jayarathna.powertools.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+public class HealthController {
+
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, Object>> health() {
+        return ResponseEntity.ok(Map.of(
+                "status", "UP",
+                "timestamp", Instant.now().toString()
+        ));
+    }
+}

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -11,3 +11,13 @@ spring:
     open-in-view: false
   flyway:
     enabled: true
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs
+  info:
+    title: PowerTools API
+    description: REST API for the PowerTools e-commerce platform
+    version: 0.0.1-SNAPSHOT

--- a/api/src/main/resources/db/migration/V1__create_products_table.sql
+++ b/api/src/main/resources/db/migration/V1__create_products_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE products (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    price DECIMAL(10, 2) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/api/src/main/resources/db/migration/V1__create_products_table.sql
+++ b/api/src/main/resources/db/migration/V1__create_products_table.sql
@@ -1,7 +1,90 @@
-CREATE TABLE products (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(255) NOT NULL,
-    description TEXT,
-    price DECIMAL(10, 2) NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+-- ============================================================
+-- PowerTools Database Schema - Flyway Migration V1
+-- Matches EER Diagram from README.md Section 7.2
+-- ============================================================
+
+-- USER (superclass for Customer and Admin)
+CREATE TABLE USER (
+    userId    INT          AUTO_INCREMENT PRIMARY KEY,
+    name      VARCHAR(255) NOT NULL,
+    email     VARCHAR(255) NOT NULL UNIQUE,
+    password  VARCHAR(255) NOT NULL,
+    role      VARCHAR(20)  NOT NULL
+);
+
+-- CATEGORY
+CREATE TABLE CATEGORY (
+    categoryId   INT          AUTO_INCREMENT PRIMARY KEY,
+    categoryName VARCHAR(255) NOT NULL,
+    description  TEXT
+);
+
+-- PRODUCT
+CREATE TABLE PRODUCT (
+    productId  INT            AUTO_INCREMENT PRIMARY KEY,
+    categoryId INT,
+    name       VARCHAR(255)   NOT NULL,
+    price      DECIMAL(10, 2) NOT NULL,
+    stockQty   INT            NOT NULL DEFAULT 0,
+    imageUrl   VARCHAR(500),
+    CONSTRAINT fk_product_category FOREIGN KEY (categoryId)
+        REFERENCES CATEGORY (categoryId)
+);
+
+-- CART
+CREATE TABLE CART (
+    cartId      INT  AUTO_INCREMENT PRIMARY KEY,
+    userId      INT  NOT NULL,
+    createdDate DATE NOT NULL,
+    CONSTRAINT fk_cart_user FOREIGN KEY (userId)
+        REFERENCES USER (userId)
+);
+
+-- CART_ITEM
+CREATE TABLE CART_ITEM (
+    cartItemId INT AUTO_INCREMENT PRIMARY KEY,
+    cartId     INT NOT NULL,
+    productId  INT NOT NULL,
+    quantity   INT NOT NULL DEFAULT 1,
+    CONSTRAINT fk_cartitem_cart FOREIGN KEY (cartId)
+        REFERENCES CART (cartId),
+    CONSTRAINT fk_cartitem_product FOREIGN KEY (productId)
+        REFERENCES PRODUCT (productId)
+);
+
+-- ORDER_ENTITY (named ORDER_ENTITY to avoid MySQL reserved word)
+CREATE TABLE ORDER_ENTITY (
+    orderId         INT            AUTO_INCREMENT PRIMARY KEY,
+    userId          INT            NOT NULL,
+    orderDate       DATE           NOT NULL,
+    totalAmount     DECIMAL(10, 2) NOT NULL,
+    status          VARCHAR(50)    NOT NULL,
+    shippingAddress VARCHAR(500)   NOT NULL,
+    CONSTRAINT fk_order_user FOREIGN KEY (userId)
+        REFERENCES USER (userId)
+);
+
+-- ORDER_ITEM
+CREATE TABLE ORDER_ITEM (
+    orderItemId INT            AUTO_INCREMENT PRIMARY KEY,
+    orderId     INT            NOT NULL,
+    productId   INT            NOT NULL,
+    quantity    INT            NOT NULL DEFAULT 1,
+    unitPrice   DECIMAL(10, 2) NOT NULL,
+    CONSTRAINT fk_orderitem_order FOREIGN KEY (orderId)
+        REFERENCES ORDER_ENTITY (orderId),
+    CONSTRAINT fk_orderitem_product FOREIGN KEY (productId)
+        REFERENCES PRODUCT (productId)
+);
+
+-- PAYMENT
+CREATE TABLE PAYMENT (
+    paymentId       INT            AUTO_INCREMENT PRIMARY KEY,
+    orderId         INT            NOT NULL,
+    amount          DECIMAL(10, 2) NOT NULL,
+    method          VARCHAR(50)    NOT NULL,
+    status          VARCHAR(50)    NOT NULL,
+    transactionDate DATE           NOT NULL,
+    CONSTRAINT fk_payment_order FOREIGN KEY (orderId)
+        REFERENCES ORDER_ENTITY (orderId)
 );

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "type": "module",
   "private": true,
+  "packageManager": "pnpm@11.25.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary

Promotes the infrastructure and CI setup from `dev` to `main`.

## Type of change

- [x] CI / build / tooling
- [x] New feature
- [x] Database migration (Flyway)

## What changed

- Spring Boot API skeleton with health check, Flyway, and Swagger/OpenAPI
- MySQL database schema via Flyway migration matching the EER diagram
- Next.js web frontend scaffold (shadcn/ui)
- GitHub Actions: backend CI, frontend CI, PR template check
- Dependabot configuration
- PR template and contributing guide

## How it was tested

- [x] Backend: `mvn clean verify` passed (Backend CI green)
- [x] Frontend: `pnpm lint` / `pnpm typecheck` / `pnpm build` passed (Frontend CI green)

## Checklist

- [x] Branch is up to date with `main` and has no merge conflicts
- [x] No secrets or credentials committed
